### PR TITLE
[type:fixbug] sofa plugin register metadata and parameters resolve

### DIFF
--- a/shenyu-client/shenyu-client-sofa/src/main/java/org/apache/shenyu/client/sofa/SofaServiceBeanPostProcessor.java
+++ b/shenyu-client/shenyu-client-sofa/src/main/java/org/apache/shenyu/client/sofa/SofaServiceBeanPostProcessor.java
@@ -53,7 +53,7 @@ public class SofaServiceBeanPostProcessor implements BeanPostProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(SofaServiceBeanPostProcessor.class);
 
-    private ShenyuClientRegisterEventPublisher publisher = ShenyuClientRegisterEventPublisher.getInstance();
+    private final ShenyuClientRegisterEventPublisher publisher = ShenyuClientRegisterEventPublisher.getInstance();
 
     private final ExecutorService executorService;
 
@@ -120,8 +120,6 @@ public class SofaServiceBeanPostProcessor implements BeanPostProcessor {
         String configRuleName = shenyuSofaClient.ruleName();
         String ruleName = ("".equals(configRuleName)) ? path : configRuleName;
         String methodName = method.getName();
-//        Class<?>[] parameterTypesClazz = method.getParameterTypes();
-
         String parameterTypes = Arrays.stream(method.getParameters())
                 .map(parameter -> {
                     StringBuilder result = new StringBuilder(parameter.getType().getName());
@@ -134,9 +132,6 @@ public class SofaServiceBeanPostProcessor implements BeanPostProcessor {
                     }
                     return result.toString();
                 }).collect(Collectors.joining(","));
-
-//        String parameterTypes = Arrays.stream(parameterTypesClazz).map(t -> t.getName())
-//                .collect(Collectors.joining(","));
         return MetaDataRegisterDTO.builder()
                 .appName(appName)
                 .serviceName(serviceName)

--- a/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/src/main/http/sofa-test-api.http
+++ b/shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/src/main/http/sofa-test-api.http
@@ -35,8 +35,10 @@ Accept: application/json
 Content-Type: application/json
 
 {
-  "id": 123,
-  "name": "test"
+  "sofaSimpleTypeBean": {
+    "id": 123,
+    "name": "test"
+  }
 }
 
 ### shengyu getway proxy findByIdsAndName
@@ -145,17 +147,19 @@ Accept: application/json
 Content-Type: application/json
 
 {
-  "sofaSimpleTypeBean": {
-    "id": "123",
-    "name": "test"
-  },
-  "idLists": [
-    123,
-    124
-  ],
-  "idMaps": {
-    "abc": "abc",
-    "cbd": "cbd"
+  "sofaComplexTypeBean": {
+    "sofaSimpleTypeBean": {
+      "id": "123",
+      "name": "test"
+    },
+    "idLists": [
+      123,
+      124
+    ],
+    "idMaps": {
+      "abc": "abc",
+      "cbd": "cbd"
+    }
   }
 }
 
@@ -204,12 +208,14 @@ Content-Type: application/json
       }
     }
   ],
-  "testKey1": {
-    "id": "123",
-    "name": "test"
-  },
-  "testKey2": {
-    "id": "123",
-    "name": "test"
+  "sofaSimpleTypeBeanMap": {
+    "testKey1": {
+      "id": "123",
+      "name": "test"
+    },
+    "testKey2": {
+      "id": "123",
+      "name": "test"
+    }
   }
 }

--- a/shenyu-plugin/shenyu-plugin-sofa/src/main/java/org/apache/shenyu/plugin/sofa/param/SofaBodyParamResolveServiceImpl.java
+++ b/shenyu-plugin/shenyu-plugin-sofa/src/main/java/org/apache/shenyu/plugin/sofa/param/SofaBodyParamResolveServiceImpl.java
@@ -17,6 +17,8 @@
 
 package org.apache.shenyu.plugin.sofa.param;
 
+import com.alipay.hessian.generic.model.GenericCollection;
+import com.alipay.hessian.generic.model.GenericMap;
 import com.alipay.hessian.generic.model.GenericObject;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -25,13 +27,10 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.shenyu.common.utils.GsonUtils;
 import org.apache.shenyu.plugin.api.param.BodyParamResolveService;
-import org.apache.shenyu.plugin.api.utils.BodyParamUtils;
 
-import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * The type Default generic param resolve service.
@@ -40,47 +39,92 @@ public class SofaBodyParamResolveServiceImpl implements BodyParamResolveService 
 
     @Override
     public Pair<String[], Object[]> buildParameter(final String body, final String parameterTypes) {
-        String[] parameterTypesAndGeneric = StringUtils.split(parameterTypes, "#");
-        String[] parameters = StringUtils.split(parameterTypesAndGeneric[0], ",");
-        if (isSingleCustomizeType(parameters)) {
-            return BodyParamUtils.buildSingleParameter(body, parameterTypes);
+        final String[] parameterTypeStrings = StringUtils.split(parameterTypes, ",");
+        List<String> parameterTypeArr = new ArrayList<>(parameterTypeStrings.length);
+        List<Object> values = new ArrayList<>();
+        final List<Object> params = new ArrayList<>(GsonUtils.getInstance().toObjectMap(body).values());
+        for (int paramIndex = 0; paramIndex < parameterTypeStrings.length; paramIndex++) {
+            final String[] parameter = StringUtils.split(parameterTypeStrings[paramIndex], "#");
+            parameterTypeArr.add(parameter[0]);
+            values.add(convertToParameterValue(params.get(paramIndex), parameter));
         }
-        LinkedList<String> genericTypes = new LinkedList<>();
-        if (parameterTypesAndGeneric.length > 1) {
-            genericTypes.addAll(Arrays.asList(StringUtils.split(parameterTypesAndGeneric[1], ",")));
+        return new ImmutablePair<>(parameterTypeArr.toArray(new String[0]), values.toArray());
+    }
+
+    /**
+     * convert to parameter value
+     *
+     * @param value         value support [json object string, json array string,string]
+     * @param parameterType parameter type support [javaPackage.ClassName#GenericType1#GenericType2], split is ,
+     * @return GenericObject, GenericMap, List, string, array...
+     * @see com.alipay.hessian.generic.model
+     */
+    @SuppressWarnings("all")
+    private Object convertToParameterValue(Object value, String[] parameterType) {
+        if (isSingleType(parameterType)) {
+            return value;
         }
-        Map<String, Object> paramMap = GsonUtils.getInstance().toObjectMap(body);
-        Object[] objects = paramMap.values().stream().map(each -> {
-            if (each instanceof JsonObject) {
-                return GsonUtils.getInstance().convertToMap(each.toString());
-            } else if (each instanceof JsonArray) {
-                if (genericTypes.isEmpty()) {
-                    return GsonUtils.getInstance().fromList(each.toString(), Object.class);
-                }
-                String type = genericTypes.pop();
-                return convertToGenericObjects(type, each);
-            } else {
-                return each;
+        if (value instanceof JsonObject && parameterType[0].contains("Map")) {
+            final Map<String, Object> mapValue = GsonUtils.getInstance().convertToMap(value.toString());
+            if (parameterType.length == 1) {
+                // no generic info
+                return mapValue;
             }
-        }).toArray();
-        return new ImmutablePair<>(parameters, objects);
+            assert parameterType.length == 3;
+            // generic map
+            final GenericMap genericMap = new GenericMap(parameterType[2]);
+            mapValue.replaceAll((k, v) -> convertToGenericObject(parameterType[2], mapValue.get(k)));
+            genericMap.setMap(mapValue);
+            return genericMap;
+        }
+        if (value instanceof JsonObject) {
+            return convertToGenericObject(parameterType[0], value);
+        }
+        if (value instanceof JsonArray) {
+            if (parameterType.length == 1) {
+                // no generic info
+                return GsonUtils.getInstance().fromList(value.toString(), Object.class);
+            }
+            // generic collection
+            final GenericCollection genericCollection = new GenericCollection(parameterType[1]);
+            genericCollection.setCollection(convertToGenericObjects(parameterType[1], ((Iterable<Object>) value)));
+            return genericCollection;
+        }
+        return value;
+    }
+
+    /**
+     * convert json object to {@link GenericObject}
+     *
+     * @param paramType  param type string
+     * @param paramValue param value (if is object, auto to convert string)
+     * @return {@link GenericObject},if is single customize type return  paramValue
+     * @see GenericObject
+     * @see this#isSingleType(String)
+     */
+    private static Object convertToGenericObject(final String paramType, final Object paramValue) {
+        if (isSingleType(paramType)) {
+            return paramValue;
+        }
+        final Map<String, Object> mapValue = GsonUtils.getInstance().convertToMap(paramValue.toString());
+        GenericObject genericObject = new GenericObject(paramType);
+        mapValue.forEach(genericObject::putField);
+        return genericObject;
     }
 
     /**
      * Convert to GenericObject.
      *
-     * @param type generic type.
-     * @param param actual parameter.
+     * @param type   generic type.
+     * @param params actual parameters.
      * @return list of GenericObject.
      */
-    @SuppressWarnings("all")
-    private static List<GenericObject> convertToGenericObjects(final String type, final Object param) {
-        List<Map> mapList = GsonUtils.getInstance().fromList(param.toString(), Map.class);
-        return mapList.stream().map(map -> {
-            GenericObject genericObject = new GenericObject(type);
-            map.forEach((key, value) -> genericObject.putField((String) key, value));
-            return genericObject;
-        }).collect(Collectors.toList());
+    private static List<Object> convertToGenericObjects(final String type, final Iterable<Object> params) {
+        List<Object> list = new ArrayList<>();
+        for (Object param : params) {
+            list.add(convertToGenericObject(type, param));
+        }
+        return list;
     }
 
     /**
@@ -89,7 +133,18 @@ public class SofaBodyParamResolveServiceImpl implements BodyParamResolveService 
      * @param parameter parameter array.
      * @return only one parameter and it's customized type return true otherwise return false.
      */
-    private static boolean isSingleCustomizeType(final String[] parameter) {
-        return parameter.length == 1 && !parameter[0].startsWith("java") && !parameter[0].startsWith("[Ljava");
+    private static boolean isSingleType(final String[] parameter) {
+        return parameter.length == 1 && isSingleType(parameter[0]);
     }
+
+    /**
+     * is single type<br>
+     * single type is package[java.xxx or [Ljava.xxx]
+     * @param parameterType parameter type.
+     * @return type is single type
+     */
+    private static boolean isSingleType(final String parameterType) {
+        return parameterType.startsWith("java");
+    }
+
 }

--- a/shenyu-plugin/shenyu-plugin-sofa/src/test/java/org/apache/shenyu/plugin/sofa/param/SofaBodyParamResolveServiceTest.java
+++ b/shenyu-plugin/shenyu-plugin-sofa/src/test/java/org/apache/shenyu/plugin/sofa/param/SofaBodyParamResolveServiceTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shenyu.plugin.sofa.param;
 
+import com.alipay.hessian.generic.model.GenericObject;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.junit.Test;
@@ -93,32 +94,29 @@ public final class SofaBodyParamResolveServiceTest {
         Pair<String[], Object[]> pair = impl.buildParameter(body, parameterTypes);
         assertThat(pair.getLeft().length, is(1));
         assertThat(pair.getRight().length, is(1));
-        Map map = (Map) pair.getRight()[0];
-        map = (Map) map.get("student");
-        assertNull(map.get("id"));
-        assertNull(map.get("name"));
+        GenericObject student = (GenericObject) pair.getRight()[0];
+        assertNull(student.getField("id"));
+        assertNull(student.getField("name"));
 
         body = "{\"students\":[{\"id\":null,\"name\":null}]}";
         parameterTypes = "org.apache.shenyu.web.rpc.DubboMultiParameterResolveServiceImplTest.Student[]";
         pair = impl.buildParameter(body, parameterTypes);
         assertThat(pair.getLeft().length, is(1));
         assertThat(pair.getRight().length, is(1));
-        map = (Map) pair.getRight()[0];
-        List list = (List) map.get("students");
-        map = (Map) list.get(0);
+        List list = (List) pair.getRight()[0];
+        Map map = (Map) list.get(0);
         assertNull(map.get("id"));
         assertNull(map.get("name"));
 
-        body = "{\"dubboTest\":{\"id\":null,\"name\":null},\"idLists\":[null,null],\"idMaps\":{\"id2\":null,\"id1\":null}}";
+        body = "{\"complexBean\":{\"dubboTest\":{\"id\":null,\"name\":null},\"idLists\":[null,null],\"idMaps\":{\"id2\":null,\"id1\":null}}}";
         parameterTypes = "org.apache.shenyu.web.rpc.DubboMultiParameterResolveServiceImplTest.ComplexBean";
         pair = impl.buildParameter(body, parameterTypes);
         assertThat(pair.getLeft().length, is(1));
         assertThat(pair.getRight().length, is(1));
-        map = (Map) pair.getRight()[0];
-        Map dubboTest = (Map) map.get("dubboTest");
-        assertNull(dubboTest.get("id"));
-        assertNull(dubboTest.get("name"));
-        list = (List) map.get("idLists");
+        GenericObject dubboTest = (GenericObject)  pair.getRight()[0];
+        assertNull(dubboTest.getField("id"));
+        assertNull(dubboTest.getField("name"));
+        list = (List) dubboTest.getField("idLists");
         assertNull(list.get(0));
         assertNull(list.get(1));
 


### PR DESCRIPTION
Fixed [#2069](https://github.com/apache/incubator-shenyu/issues/2069)
client register metadata type[no Generic],but sofa need GenericObject,

sofa plugin resolve parameters method can't support convert GenericObject

if param is Map ,it convert to error

work list:

- fix the loss of generics in client registration metadata parameters
- fix the param resolve bug.
- fix unit test param resolve
- fix sofa-test-api.http file

warning : resolve Map method【Not rigorous】，I need better way